### PR TITLE
Draw lines with smaller gaps between individual characters.

### DIFF
--- a/tree/main.go
+++ b/tree/main.go
@@ -59,13 +59,13 @@ func visit(path, indent string) (dirs, files int, err error) {
 		return 1, 0, fmt.Errorf("read dir names %s: %v", path, err)
 	}
 	sort.Strings(names)
-	add := "|   "
+	add := "│   "
 	for i, name := range names {
 		if i == len(names)-1 {
-			fmt.Printf(indent + "`-- ")
+			fmt.Printf(indent + "└── ")
 			add = "    "
 		} else {
-			fmt.Printf(indent + "|-- ")
+			fmt.Printf(indent + "├── ")
 		}
 		d, f, err := visit(filepath.Join(path, name), indent+add)
 		if err != nil {


### PR DESCRIPTION
What do you think of this change?

Before:

```
    |-- CONTRIBUTING.md
    |-- LICENSE
    |-- README.md
    |-- httplog
    |   |-- README.md
    |   |-- transport.go
    |   `-- transport_test.go
    `-- tree
        |-- README.md
        `-- main.go
```

After:

```
    ├── CONTRIBUTING.md
    ├── LICENSE
    ├── README.md
    ├── httplog
    │   ├── README.md
    │   ├── transport.go
    │   └── transport_test.go
    └── tree
        ├── README.md
        └── main.go
```
